### PR TITLE
When sending data over the wire, use UTC timestamps

### DIFF
--- a/beaver/rabbitmq_transport.py
+++ b/beaver/rabbitmq_transport.py
@@ -50,7 +50,7 @@ class RabbitmqTransport(beaver.transport.Transport):
 
 
     def callback(self, filename, lines):
-        timestamp = datetime.datetime.now().isoformat()
+        timestamp = datetime.datetime.utcnow().isoformat()
         for line in lines:
             json_msg = json.dumps({
                 '@source': "file://{0}{1}".format(self.current_host, filename),

--- a/beaver/redis_transport.py
+++ b/beaver/redis_transport.py
@@ -19,7 +19,7 @@ class RedisTransport(beaver.transport.Transport):
         self.redis_namespace = os.environ.get("REDIS_NAMESPACE", "logstash:beaver")
 
     def callback(self, filename, lines):
-        timestamp = datetime.datetime.now().isoformat()
+        timestamp = datetime.datetime.utcnow().isoformat()
         for line in lines:
             self.redis.lpush(
                 self.redis_namespace,

--- a/beaver/zmq_transport.py
+++ b/beaver/zmq_transport.py
@@ -22,7 +22,7 @@ class ZmqTransport(beaver.transport.Transport):
             self.pub.connect(zeromq_address)
 
     def callback(self, filename, lines):
-        timestamp = datetime.datetime.now().isoformat()
+        timestamp = datetime.datetime.utcnow().isoformat()
         for line in lines:
             self.pub.send(self.format(filename, timestamp, line))
 


### PR DESCRIPTION
I fell down a rabbit hole because of this, happy to go into more detail if you like but most of it is in the logstash irc channel

I've left the logging function and the stdout transport as .now() as if they're intended for debugging then you probably only want local time, but you may feel its more correct to 'utcnow()' them too.
