### PR TITLE
add default echo stream handler for stdout transport

### DIFF
--- a/bin/beaver
+++ b/bin/beaver
@@ -55,7 +55,9 @@ parser.set_defaults(
     transport=os.environ.get("BEAVER_TRANSPORT", 'stdout')
 )
 
-
 args = parser.parse_args()
+
+if args.transport == 'stdout':
+    logging.getLogger().addHandler(logging.StreamHandler())
 
 beaver.worker.run_worker(args)


### PR DESCRIPTION
the utils.log() helper routine calls logging.info() but the default log instance does not define a stream handler so the output falls to the floor

adding a default stream handler if the transport is stdout solves this in a silly-simple way
