### PR TITLE
lpush changed to rpush on redis transport

### DIFF
--- a/beaver/redis_transport.py
+++ b/beaver/redis_transport.py
@@ -21,7 +21,7 @@ class RedisTransport(beaver.transport.Transport):
     def callback(self, filename, lines):
         timestamp = datetime.datetime.utcnow().isoformat()
         for line in lines:
-            self.redis.lpush(
+            self.redis.rpush(
                 self.redis_namespace,
                 self.format(filename, timestamp, line)
             )


### PR DESCRIPTION
This is required to read the events in the correct order on the logstash side. Using lpush sometimes events closely spaced will be read disordered.

See the logstash redis output plugin:

https://github.com/logstash/logstash/blob/6f745110671b5d9d66bf082fbfed99d145af4620/lib/logstash/outputs/redis.rb#L4
