### PR TITLE
timestamp in ISO 8601 format with the "Z" sufix to express UTC

### DIFF
--- a/beaver/rabbitmq_transport.py
+++ b/beaver/rabbitmq_transport.py
@@ -47,7 +47,7 @@ class RabbitmqTransport(beaver.transport.Transport):
         )
 
     def callback(self, filename, lines):
-        timestamp = datetime.datetime.utcnow().isoformat()
+        timestamp = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         for line in lines:
             self.channel.basic_publish(
                 exchange=self.rabbitmq_exchange,

--- a/beaver/redis_transport.py
+++ b/beaver/redis_transport.py
@@ -19,7 +19,7 @@ class RedisTransport(beaver.transport.Transport):
         self.redis_namespace = os.environ.get("REDIS_NAMESPACE", "logstash:beaver")
 
     def callback(self, filename, lines):
-        timestamp = datetime.datetime.utcnow().isoformat()
+        timestamp = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         for line in lines:
             self.redis.rpush(
                 self.redis_namespace,

--- a/beaver/stdout_transport.py
+++ b/beaver/stdout_transport.py
@@ -6,7 +6,7 @@ import beaver.transport
 class StdoutTransport(beaver.transport.Transport):
 
     def callback(self, filename, lines):
-        timestamp = datetime.datetime.utcnow().isoformat()
+        timestamp = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
         for line in lines:
             print self.format(filename, timestamp, line)

--- a/beaver/udp_transport.py
+++ b/beaver/udp_transport.py
@@ -16,7 +16,7 @@ class UdpTransport(beaver.transport.Transport):
         self.udp_port = int(os.environ.get("UDP_PORT", 9999))
 
     def callback(self, filename, lines):
-        timestamp = datetime.datetime.utcnow().isoformat()
+        timestamp = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         for line in lines:
             formatted = self.format(filename, timestamp, line)
             self.sock.sendto(formatted, (self.udp_host, self.udp_port))

--- a/beaver/zmq_transport.py
+++ b/beaver/zmq_transport.py
@@ -22,7 +22,7 @@ class ZmqTransport(beaver.transport.Transport):
             self.pub.connect(zeromq_address)
 
     def callback(self, filename, lines):
-        timestamp = datetime.datetime.utcnow().isoformat()
+        timestamp = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         for line in lines:
             self.pub.send(self.format(filename, timestamp, line))
 


### PR DESCRIPTION
_ISO 88601_ datetimes in Python do not return the time zone. Therefore, timestamps can be misinterpreted.
### In JRuby (logstash)

``` ruby
$ jruby -S irb
irb(main):001:0> DateTime = org.joda.time.DateTime
=> Java::OrgJodaTime::DateTime
irb(main):002:0> DateTimeZone = org.joda.time.DateTimeZone
=> Java::OrgJodaTime::DateTimeZone
irb(main):003:0> DateTime.new(DateTimeZone::UTC).to_s
=> "2012-11-13T16:18:36.967Z"
```

Time zone to UTC with the _Z_.
### In Ruby (logstash)

``` ruby
$ irb
irb(main):001:0> ISO8601_STRFTIME = "%04d-%02d-%02dT%02d:%02d:%02d.%06d%+03d:00".freeze
=> "%04d-%02d-%02dT%02d:%02d:%02d.%06d%+03d:00"
irb(main):002:0> now = Time.new.utc
=> Tue Nov 13 16:18:53 UTC 2012
irb(main):003:0> sprintf(ISO8601_STRFTIME, now.year, now.month, now.day, now.hour,
irb(main):004:1*         now.min, now.sec, now.tv_usec, now.utc_offset / 3600)
=> "2012-11-13T16:18:53.090509+00:00"
```

Time zone to UTC with the _+00:00_.
### In Python (beaver)

``` python
$ python
Python 2.6.5 (r265:79063, Apr 16 2010, 13:57:41)
>>> import datetime
>>> datetime.datetime.utcnow().isoformat()
'2012-11-13T16:19:07.699141'
```

We must add a _Z_ at the end to always be interpreted as UTC.

``` python
>>> datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
'2012-11-13T16:20:51.358235Z'
```
