### PR TITLE
Beaver sends empty string as tag

### DIFF
--- a/beaver/config.py
+++ b/beaver/config.py
@@ -96,6 +96,7 @@ class Config():
     def gettags(self, filename):
         try:
             result = self._getfield(filename, 'tags').split(",")
+            result = filter(None, result)
             return result if result else []
         except TypeError:
             return []


### PR DESCRIPTION
Beaver sends an empty string as a tag instead of an empty list when reading from a configuration file with no tags.
