### PR TITLE
Unwatch file when encountering a stale NFS handle.

### DIFF
--- a/beaver/worker.py
+++ b/beaver/worker.py
@@ -71,7 +71,11 @@ class Worker(object):
         while 1:
             self.update_files()
             for fid, file in list(self.files_map.iteritems()):
-                self.readfile(file)
+                try:
+                    self.readfile(file)
+                except IOError, e:
+                    if e.errno == errno.ESTALE:
+                        self.unwatch(file, fid)
             if async:
                 return
             time.sleep(interval)


### PR DESCRIPTION
When an NFS file handle becomes stale (ie, file was removed), it was
crashing beaver.  Need to just unwatch file.
