### PR TITLE
Adding support for /path/{foo,bar}.log

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -156,6 +156,10 @@ Example 10: Read config from config.ini and put to stdout::
     type: syslog
     tags: sys
 
+    [/var/log/{secure,messages}.log]
+    type: syslog
+    tags: sys
+
 Example 11: UDP transport::
 
     # From the commandline

--- a/beaver/config.py
+++ b/beaver/config.py
@@ -1,7 +1,7 @@
 import ConfigParser
-import glob
 import logging
 import os
+from utils import eglob
 
 
 class Config():
@@ -61,7 +61,7 @@ class Config():
             config = dict((x[0], x[1]) for x in self._config.items(filename))
             glob_paths[filename] = config
 
-            globs = glob.glob(filename)
+            globs = eglob(filename)
             if not globs:
                 logger.info('Skipping glob due to no files found: %s' % filename)
                 continue

--- a/beaver/utils.py
+++ b/beaver/utils.py
@@ -1,4 +1,7 @@
 import logging
+import glob
+import re
+import itertools
 
 
 def setup_custom_logger(name, debug=False):
@@ -16,3 +19,39 @@ def setup_custom_logger(name, debug=False):
 
     logger.addHandler(handler)
     return logger
+
+def _replace_all(path, replacements):
+    for j in replacements:
+        path = path.replace(*j)
+    return path
+
+def eglob(path):
+    """Like glob.glob, but supports "/path/**/{a,b,c}.txt" lookup"""
+    fi = itertools.chain.from_iterable
+    paths = expand_paths(path)
+    return list(fi(glob.iglob(d) for d in paths))
+
+_magic_brackets = re.compile("({([^}]+)})")
+def expand_paths(path):
+    """When given a path with brackets, expands it to return all permutations
+       of the path with expanded brackets, similar to ant.
+
+       >>> expand_paths("../{a,b}/{c,d}")
+       ['../a/c', '../a/d', '../b/c', '../b/d']
+       >>> expand_paths("../{a,b}/{a,b}.py")
+       ['../a/a.py', '../a/b.py', '../b/a.py', '../b/b.py']
+       >>> expand_paths("../{a,b,c}/{a,b,c}")
+       ['../a/a', '../a/b', '../a/c', '../b/a', '../b/b', '../b/c', '../c/a', '../c/b', '../c/c']
+       >>> expand_paths("test")
+       ['test']
+       >>> expand_paths("")
+    """
+    pr = itertools.product
+    parts = _magic_brackets.findall(path)
+    if path == "":
+        return
+    elif not parts:
+        return [path]
+
+    permutations = [[(p[0], i, 1) for i in p[1].split(",")] for p in parts]
+    return [_replace_all(path, i) for i in pr(*permutations)]

--- a/beaver/worker.py
+++ b/beaver/worker.py
@@ -1,11 +1,11 @@
 import errno
-import glob
 import logging
 import os
 import stat
 import sys
 import time
 from transport import TransportException
+from utils import eglob
 
 
 class Worker(object):
@@ -128,7 +128,7 @@ class Worker(object):
         files = []
         if len(self.args.globs) > 0:
             for name in self.args.globs:
-                globbed = [os.path.realpath(filename) for filename in glob.glob(name)]
+                globbed = [os.path.realpath(filename) for filename in eglob(name)]
                 files.extend(globbed)
                 self.configfile.addglob(name, globbed)
         else:


### PR DESCRIPTION
I need to name servers by name in the config, for example:

```
[/mnt/apps/server1/logfile.log]
... config
[/mnt/apps/server2/logfile.log]
... config
[/mnt/apps/server3/logfile.log]
... config
```

Where the config was the same for each log.  So I added bash-style:

```
[/mnt/apps/{server1,server2,server3}/logfile.log]
... config
```

I could just use globs, but I figured this would be useful.  Let me know your thoughts.
