### PR TITLE
add optional support for socket.getfqdn

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Usage
 usage::
 
     beaver [-h] [-m {bind,connect}] [-p PATH] [-f FILES [FILES ...]]
-              [-t {rabbitmq,redis,stdout,zmq,udp}] [-c CONFIG] [-d DEBUG]
+              [-t {rabbitmq,redis,stdout,zmq,udp}] [-c CONFIG] [-d DEBUG] [--fqdn]
 
 optional arguments::
 
@@ -46,6 +46,8 @@ optional arguments::
                         ini config file path
     -d DEBUG, --debug DEBUG
                         enable debug mode
+    --fqdn
+                        use the machine's FQDN for source_host
 
 Background
 ==========

--- a/beaver/rabbitmq_transport.py
+++ b/beaver/rabbitmq_transport.py
@@ -8,8 +8,8 @@ from beaver.transport import TransportException
 
 class RabbitmqTransport(beaver.transport.Transport):
 
-    def __init__(self, configfile):
-        super(RabbitmqTransport, self).__init__(configfile)
+    def __init__(self, configfile, args):
+        super(RabbitmqTransport, self).__init__(configfile, args)
 
         # Create our connection object
         rabbitmq_address = os.environ.get("RABBITMQ_HOST", "localhost")

--- a/beaver/redis_transport.py
+++ b/beaver/redis_transport.py
@@ -8,8 +8,8 @@ import beaver.transport
 
 class RedisTransport(beaver.transport.Transport):
 
-    def __init__(self, configfile):
-        super(RedisTransport, self).__init__(configfile)
+    def __init__(self, configfile, args):
+        super(RedisTransport, self).__init__(configfile, args)
 
         redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
         _url = urlparse.urlparse(redis_url, scheme="redis")

--- a/beaver/transport.py
+++ b/beaver/transport.py
@@ -21,8 +21,10 @@ else:
 
 class Transport(object):
 
-    def __init__(self, configfile):
+    def __init__(self, configfile, args):
         self.current_host = socket.gethostname()
+        if args.fqdn == True:
+            self.current_host = socket.getfqdn()
         self.configfile = configfile
         if BEAVER_FORMAT == 'msgpack':
             self.packer = msgpack.Packer()

--- a/beaver/udp_transport.py
+++ b/beaver/udp_transport.py
@@ -7,8 +7,8 @@ import beaver.transport
 
 class UdpTransport(beaver.transport.Transport):
 
-    def __init__(self, configfile):
-        super(UdpTransport, self).__init__(configfile)
+    def __init__(self, configfile, args):
+        super(UdpTransport, self).__init__(configfile, args)
 
         self.sock = socket.socket(socket.AF_INET,  # Internet
             socket.SOCK_DGRAM)  # UDP

--- a/beaver/worker.py
+++ b/beaver/worker.py
@@ -219,16 +219,16 @@ def run_worker(configfile, args):
 
     if args.transport == 'rabbitmq':
         import beaver.rabbitmq_transport
-        transport = beaver.rabbitmq_transport.RabbitmqTransport(configfile)
+        transport = beaver.rabbitmq_transport.RabbitmqTransport(configfile, args)
     elif args.transport == 'redis':
         import beaver.redis_transport
-        transport = beaver.redis_transport.RedisTransport(configfile)
+        transport = beaver.redis_transport.RedisTransport(configfile, args)
     elif args.transport == 'stdout':
         import beaver.stdout_transport
-        transport = beaver.stdout_transport.StdoutTransport(configfile)
+        transport = beaver.stdout_transport.StdoutTransport(configfile, args)
     elif args.transport == 'udp':
         import beaver.udp_transport
-        transport = beaver.udp_transport.UdpTransport(configfile)
+        transport = beaver.udp_transport.UdpTransport(configfile, args)
     elif args.transport == 'zmq':
         import beaver.zmq_transport
         transport = beaver.zmq_transport.ZmqTransport(configfile, args)

--- a/beaver/zmq_transport.py
+++ b/beaver/zmq_transport.py
@@ -8,7 +8,7 @@ import beaver.transport
 class ZmqTransport(beaver.transport.Transport):
 
     def __init__(self, configfile, args):
-        super(ZmqTransport, self).__init__(configfile)
+        super(ZmqTransport, self).__init__(configfile, args)
 
         zeromq_address = os.environ.get("ZEROMQ_ADDRESS", "tcp://localhost:2120")
         self.zeromq_bind = (args.mode == "bind")

--- a/bin/beaver
+++ b/bin/beaver
@@ -53,6 +53,7 @@ parser.add_argument('-t', '--transport', help='log transport method', dest='tran
 parser.add_argument('-c', '--configfile', help='ini config file path', dest='config')
 parser.add_argument('-d', '--debug', help='enable debug mode', type=bool, dest='debug')
 parser.add_argument('-v', '--version', help='output version and quit', dest='version', action='store_true')
+parser.add_argument('--fqdn', help="use the machine's FQDN", dest="fqdn", action='store_true')
 
 
 # Support env variable parsing as well
@@ -68,7 +69,8 @@ parser.set_defaults(
     files=files,
     transport=os.environ.get("BEAVER_TRANSPORT", 'stdout'),
     config='/dev/null',
-    debug=False
+    debug=False,
+    fqdn=False
 )
 
 args = parser.parse_args()


### PR DESCRIPTION
For my setup I need to have the fqdn used at all times since my
hostnames are the same but the environment (among other things) is
found in the rest of the FQDN.

Since just changing socket.gethostname to socket.getfqdn has lots of
potential for breakage, and socket.gethostname doesn't always return an
FQDN, it's now an option to explicitly always use the fqdn.

Fixes #68

As for how the arg is making it into the transport.**init** method, there some precedent for doing this (passing args to the transport constructor) in the ZmqTransport class, and it could be potentially useful later.
