### PR TITLE
Implement fully recursive file globing.

### DIFF
--- a/beaver/utils.py
+++ b/beaver/utils.py
@@ -1,5 +1,5 @@
 import argparse
-import glob
+import glob2
 import itertools
 import logging
 import platform
@@ -95,7 +95,7 @@ def eglob(path):
     """Like glob.glob, but supports "/path/**/{a,b,c}.txt" lookup"""
     fi = itertools.chain.from_iterable
     paths = expand_paths(path)
-    return list(fi(glob.iglob(d) for d in paths))
+    return list(fi(glob2.iglob(d) for d in paths))
 
 
 def expand_paths(path):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,3 +2,4 @@ pika>=0.9.5
 python-daemon>=1.5.2
 redis==2.4.11
 ujson>=1.9
+glob2==0.3

--- a/requirements/base26.txt
+++ b/requirements/base26.txt
@@ -3,3 +3,4 @@ pika>=0.9.5
 python-daemon>=1.5.2
 redis==2.4.11
 ujson>=1.9
+glob2==0.3


### PR DESCRIPTION
Python's base glob.iglob does not operate as if globstar were in effect. To
explain, let's say I have an erlang application with lager logs to

```
/var/log/erl_app/lags.log
/var/log/erl_app/console/YEAR_MONTH_DAY.log
```

and webmachine logs to

```
/var/log/erl_app/webmachine/access/YEAR_MONTH_DAY.log
```

Prior to this commit, when configured with the path `/var/log/**/*.log` all
webmachine logs would be ignored by beaver. This is no longer the case, to an
arbitrary depth.

Signed-off-by: Brian L. Troutwine brian@troutwine.us
