### PR TITLE
SSH tunnel is not re-connecting

### DIFF
--- a/beaver/ssh_tunnel.py
+++ b/beaver/ssh_tunnel.py
@@ -54,7 +54,9 @@ class BeaverSshTunnel(BeaverSubprocess):
         remote_host = beaver_config.get('ssh_remote_host')
         remote_port = beaver_config.get('ssh_remote_port')
 
-        self._subprocess = subprocess.Popen(["ssh", "-i", key_file, "-f", tunnel, "-L",
-            "{0}:{1}:{2}".format(tunnel_port, remote_host, remote_port),
-            "sleep 5"], stdout=subprocess.PIPE, preexec_fn=os.setsid)
+        self._subprocess = subprocess.Popen(["/bin/sh", "-c",
+            "while true; do ssh -n -N -o BatchMode=yes -i '{3}' '{4}' -L '{0}:{1}:{2}'; sleep 10; done"
+                .format(tunnel_port, remote_host, remote_port, key_file, tunnel)
+            ], preexec_fn=os.setsid)
+
         self.poll()


### PR DESCRIPTION
If the SSH tunnel breaks for any reason, for example due to a reboot of the remote server, or due to a temporary network outage, Beaver will not try to re-connect the tunnel and will be stuck in a loop, continuously failing to connect through the broken tunnel.

Please see the attached pull request. It's my attempt at implementing a simple auto-reconnect mechanism. I've tested it with CentOS 6.
