### PR TITLE
alternative for reading python requirements

### DIFF
--- a/requirements/base26.txt
+++ b/requirements/base26.txt
@@ -1,2 +1,1 @@
--r base.txt
 argparse>=1.2.0

--- a/setup.py
+++ b/setup.py
@@ -11,13 +11,9 @@ except ImportError:
     from distutils.core import setup
 
 
-requirements = []
+requirements = open('requirements/base.txt').readlines()
 if sys.version_info[:2] <= (2, 6):
-    with open('requirements/base26.txt') as f:
-        requirements = f.read().splitlines()
-else:
-    with open('requirements/base.txt') as f:
-        requirements = f.read().splitlines()
+    requirements.extend(open('requirements/base26.txt').readlines())
 
 setup(
     name='Beaver',


### PR DESCRIPTION
I know very little python so this may be completely wrong, but this fixes #120 on my CentOS 6.3 machine.  

My guess is the "-r base.txt" is what is causing the issue although I cannot find any documentation as to what the -r (or -x and -e flags for that matter) does, but it appears to also load requirements from a second file as well.  Achieving that through code rather than the -r flag.
