### PR TITLE
Fixed a typo on the SQS docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -292,7 +292,7 @@ Example 11: SQS Transport::
 
     # logstash indexer config:
     input {
-      sqs_fillz {
+      sqs {
         queue => "logstash-input"
         type => "shipper-input"
         format => "json_event"


### PR DESCRIPTION
I accidentally left in a local-edit to SQS docs for a custom logstash plugin.  Fixed it.
