### PR TITLE
Allow string escapes in delimiter

### DIFF
--- a/beaver/config.py
+++ b/beaver/config.py
@@ -31,7 +31,8 @@ class BeaverConfig():
             'ignore_truncate': '0',
 
             # buffered tokenization
-            'delimiter': "\n",
+            # we string-escape the delimiter later so that we can put escaped characters in our config file
+            'delimiter': '\n',
             'size_limit': '',
 
             'message_format': '',
@@ -349,6 +350,8 @@ class BeaverConfig():
             require_bool = ['debug', 'ignore_empty', 'ignore_truncate']
             for k in require_bool:
                 config[k] = bool(int(config[k]))
+
+            config['delimiter'] = config['delimiter'].decode('string-escape')
 
             require_int = ['sincedb_write_interval', 'stat_interval', 'tail_lines']
             for k in require_int:


### PR DESCRIPTION
As far as I can tell, there is no way for me to represent a newline as
a delimiter in a configuration file with ConfigParser. I want to do this:

```
  [/ephemeral_storage/logs/kind_of_special.log]
  tags: special
  type: special
  delimiter: \n\n
```

As the log has a blank line between its multiline entries.

My change allows that, by making delimiter not string-escaped until
after the config file is parsed. I'm naive about python, so there is a
strong possibility I've gone about it horribly wrong. This would also
easily allow splitting on nulls, tabs, unicode characters and other
things that ConfigParser may not find kosher.

By doing this sort of multiline parsing with beaver, it allows one to
run logstash without the multiline filter, which due to its lack of
thread-safety, forces you to run logstash with only one worker thread.
