### PR TITLE
Redis 2.4.11 is no longer available on Pypi

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,4 +5,4 @@ mosquitto>=1.1
 msgpack-pure>=0.1.3
 pika>=0.9.12
 python-daemon>=1.5.2
-redis==2.4.11
+redis>=2.4.11


### PR DESCRIPTION
Fixes issue #167
