### PR TITLE
Use os._exit over sys.exit in signal handlers to quit cleanly

### DIFF
--- a/beaver/dispatcher/tail.py
+++ b/beaver/dispatcher/tail.py
@@ -2,7 +2,7 @@
 import multiprocessing
 import Queue
 import signal
-import sys
+import os
 
 from beaver.config import BeaverConfig
 from beaver.queue import run_queue
@@ -48,7 +48,7 @@ def run(args=None):
             ssh_tunnel.close()
 
         logger.info("Shutdown complete.")
-        return sys.exit(signalnum)
+        return os._exit(signalnum)
 
     signal.signal(signal.SIGTERM, cleanup)
     signal.signal(signal.SIGINT, cleanup)

--- a/beaver/dispatcher/worker.py
+++ b/beaver/dispatcher/worker.py
@@ -2,7 +2,7 @@
 import multiprocessing
 import Queue
 import signal
-import sys
+import os
 
 from beaver.config import BeaverConfig
 from beaver.queue import run_queue
@@ -43,7 +43,7 @@ def run(args):
             ssh_tunnel.close()
 
         logger.info('Shutdown complete.')
-        return sys.exit(signalnum)
+        return os._exit(signalnum)
 
     signal.signal(signal.SIGTERM, cleanup)
     signal.signal(signal.SIGINT, cleanup)


### PR DESCRIPTION
As per
http://thushw.blogspot.co.uk/2010/12/python-dont-use-sysexit-inside-signal.html
the use of `sys.exit` inside the signal handlers means that a
`SystemExit` exception is raised
(http://docs.python.org/2/library/sys.html#sys.exit) which can be caught
by try/except blocks that might have been executing at time of signal
handling, resulting in beaver failing to quit
