### PR TITLE
Make consumer check threaded to prevent wedge state

### DIFF
--- a/beaver/worker/tail_manager.py
+++ b/beaver/worker/tail_manager.py
@@ -47,11 +47,18 @@ class TailManager(BaseLog):
             if tail.active:
                 self._tails[tail.fid()] = tail
 
+    def create_queue_consumer_if_required(self, interval=5.0):
+        if not (self._proc and self._proc.is_alive()):
+            self._proc = self._create_queue_consumer()
+        timer = threading.Timer(interval, self.create_queue_consumer_if_required)
+        timer.start()
+
     def run(self, interval=0.1,):
+
+        self.create_queue_consumer_if_required()
+
         while self._active:
             for fid in self._tails.keys():
-                if not (self._proc and self._proc.is_alive()):
-                    self._proc = self._create_queue_consumer()
 
                 self.update_files()
 


### PR DESCRIPTION
This moves the consumer process check and creation out into a timed thread. It allows the producer to end up in a wedged state (attempting to push to a full queue causing a block) and still be able to start the consumer process if it dies for some reason instead of remaining in a frozen state.
