### PR TITLE
Convert producer to process. Allow timed producer culling.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,6 +135,10 @@ The following can also be passed via argparse. Argparse will override all option
 * fqdn: Default ``False``. Whether to use the machine's FQDN in transport output
 * hostname: Default ``None``. Manually specified hostname
 
+The following configuration key allows cleaning up the worker and transport sub-processes on an interval respawning
+
+* refresh_worker_process: Default ``None``. Interval between sub-process cleanup
+
 Examples
 --------
 

--- a/beaver/config.py
+++ b/beaver/config.py
@@ -96,6 +96,9 @@ class BeaverConfig():
             # time in seconds from last command sent before a queue kills itself
             'queue_timeout': '60',
 
+            # kill and respawn worker process after given number of seconds
+            'refresh_worker_process': '',
+
             # time in seconds to wait on queue.get() block before raising Queue.Empty exception
             'wait_timeout': '5',
 
@@ -264,6 +267,7 @@ class BeaverConfig():
                 'rabbitmq_port',
                 'respawn_delay',
                 'subprocess_poll_sleep',
+                'refresh_worker_process',
                 'tcp_port',
                 'udp_port',
                 'wait_timeout',

--- a/beaver/dispatcher/tail.py
+++ b/beaver/dispatcher/tail.py
@@ -3,6 +3,7 @@ import multiprocessing
 import Queue
 import signal
 import os
+import time
 
 from beaver.config import BeaverConfig
 from beaver.queue import run_queue
@@ -20,7 +21,7 @@ def run(args=None):
 
     queue = multiprocessing.JoinableQueue(beaver_config.get('max_queue_size'))
 
-    manager = None
+    manager_proc = None
     ssh_tunnel = create_ssh_tunnel(beaver_config, logger=logger)
 
     def queue_put(*args):
@@ -30,28 +31,32 @@ def run(args=None):
         return queue.put_nowait(*args)
 
     def cleanup(signalnum, frame):
-        sig_name = tuple((v) for v, k in signal.__dict__.iteritems() if k == signalnum)[0]
-        logger.info("{0} detected".format(sig_name))
-        logger.info("Shutting down. Please wait...")
-
-        if manager is not None:
-            logger.info("Closing worker...")
-            try:
-                manager.close()
-            except RuntimeError:
-                pass
+        if signalnum is not None:
+            sig_name = tuple((v) for v, k in signal.__dict__.iteritems() if k == signalnum)[0]
+            logger.info("{0} detected".format(sig_name))
+            logger.info("Shutting down. Please wait...")
+        else:
+            logger.info('Worker process cleanup in progress...')
 
         try:
             queue_put_nowait(("exit", ()))
         except Queue.Full:
             pass
 
+        if manager_proc is not None:
+            try:
+                manager_proc.terminate()
+                manager_proc.join()
+            except RuntimeError:
+                pass
+
         if ssh_tunnel is not None:
             logger.info("Closing ssh tunnel...")
             ssh_tunnel.close()
 
-        logger.info("Shutdown complete.")
-        return os._exit(signalnum)
+        if signalnum is not None:
+            logger.info("Shutdown complete.")
+            return os._exit(signalnum)
 
     signal.signal(signal.SIGTERM, cleanup)
     signal.signal(signal.SIGINT, cleanup)
@@ -65,16 +70,36 @@ def run(args=None):
         proc.start()
         return proc
 
-    if REOPEN_FILES:
-        logger.debug("Detected non-linux platform. Files will be reopened for tailing")
+    def create_queue_producer():
+        manager = TailManager(
+            beaver_config=beaver_config,
+            queue_consumer_function=create_queue_consumer,
+            callback=queue_put,
+            logger=logger
+        )
+        manager.run()
 
-    logger.info("Starting worker...")
-    manager = TailManager(
-        beaver_config=beaver_config,
-        queue_consumer_function=create_queue_consumer,
-        callback=queue_put,
-        logger=logger
-    )
+    while 1:
 
-    logger.info("Working...")
-    manager.run()
+        try:
+
+            if REOPEN_FILES:
+                logger.debug("Detected non-linux platform. Files will be reopened for tailing")
+
+            t = time.time()
+            while True:
+                if manager_proc is None or not manager_proc.is_alive():
+                    logger.info('Starting worker...')
+                    t = time.time()
+                    manager_proc = multiprocessing.Process(target=create_queue_producer)
+                    manager_proc.start()
+                    logger.info('Working...')
+                manager_proc.join(10)
+
+                if beaver_config.get('refresh_worker_process'):
+                    if beaver_config.get('refresh_worker_process') < time.time() - t:
+                        logger.info('Worker has exceeded refresh limit. Terminating process...')
+                        cleanup(None, None)
+
+        except KeyboardInterrupt:
+            pass

--- a/beaver/dispatcher/worker.py
+++ b/beaver/dispatcher/worker.py
@@ -3,13 +3,13 @@ import multiprocessing
 import Queue
 import signal
 import os
+import time
 
 from beaver.config import BeaverConfig
 from beaver.queue import run_queue
 from beaver.ssh_tunnel import create_ssh_tunnel
 from beaver.utils import setup_custom_logger, REOPEN_FILES
 from beaver.worker.worker import Worker
-
 
 def run(args=None):
     logger = setup_custom_logger('beaver', args)
@@ -20,33 +20,36 @@ def run(args=None):
 
     queue = multiprocessing.Queue(beaver_config.get('max_queue_size'))
 
-    worker = None
+    worker_proc = None
     ssh_tunnel = create_ssh_tunnel(beaver_config, logger=logger)
 
     def cleanup(signalnum, frame):
-        sig_name = tuple((v) for v, k in signal.__dict__.iteritems() if k == signalnum)[0]
-
-        logger.info('{0} detected'.format(sig_name))
-        logger.info('Shutting down. Please wait...')
-
-        if worker is not None:
-            logger.info('Closing worker...')
-            try:
-                worker.close()
-            except RuntimeError:
-                pass
+        if signalnum is not None:
+            sig_name = tuple((v) for v, k in signal.__dict__.iteritems() if k == signalnum)[0]
+            logger.info('{0} detected'.format(sig_name))
+            logger.info('Shutting down. Please wait...')
+        else:
+            logger.info('Worker process cleanup in progress...')
 
         try:
             queue.put_nowait(('exit', ()))
         except Queue.Full:
             pass
 
+        if worker_proc is not None:
+            try:
+                worker_proc.terminate()
+                worker_proc.join()
+            except RuntimeError:
+                pass
+
         if ssh_tunnel is not None:
             logger.info('Closing ssh tunnel...')
             ssh_tunnel.close()
 
-        logger.info('Shutdown complete.')
-        return os._exit(signalnum)
+        if signalnum is not None:
+            logger.info('Shutdown complete.')
+            return os._exit(signalnum)
 
     signal.signal(signal.SIGTERM, cleanup)
     signal.signal(signal.SIGINT, cleanup)
@@ -60,16 +63,30 @@ def run(args=None):
         proc.start()
         return proc
 
+    def create_queue_producer():
+        worker = Worker(beaver_config, queue_consumer_function=create_queue_consumer, callback=queue.put, logger=logger)
+        worker.loop()
+
     while 1:
+
         try:
             if REOPEN_FILES:
                 logger.debug('Detected non-linux platform. Files will be reopened for tailing')
 
-            logger.info('Starting worker...')
-            worker = Worker(beaver_config, queue_consumer_function=create_queue_consumer, callback=queue.put, logger=logger)
+            t = time.time()
+            while True:
+                if worker_proc is None or not worker_proc.is_alive():
+                    logger.info('Starting worker...')
+                    t = time.time()
+                    worker_proc = multiprocessing.Process(target=create_queue_producer)
+                    worker_proc.start()
+                    logger.info('Working...')
+                worker_proc.join(10)
 
-            logger.info('Working...')
-            worker.loop()
+                if beaver_config.get('refresh_worker_process'):
+                    if beaver_config.get('refresh_worker_process') < time.time() - t:
+                        logger.info('Worker has exceeded refresh limit. Terminating process...')
+                        cleanup(None, None)
 
         except KeyboardInterrupt:
             pass


### PR DESCRIPTION
This moves the producer into a subprocess, allowing the parent process to simply monitor and keep it alive. This is related to #186 where parent processes were seen ballooning memory, which in turn resulted in bloated child processes when consumer processes were re-created (ballooning memory due in part to issues around frequent consumer restarts #197). An addition a `refresh_worker_process` configuration value allows providing an optional integer value representing the number of seconds the worker process should run before it is cleaned and re-spawned. Would love to get some feedback and will update the README + rebase if everything looks good. Thanks!
