### PR TITLE
Import threading library in tail manager since we want to use it

### DIFF
--- a/beaver/worker/tail_manager.py
+++ b/beaver/worker/tail_manager.py
@@ -4,6 +4,7 @@ import os
 import stat
 import time
 import signal
+import threading
 
 from beaver.utils import eglob
 from beaver.base_log import BaseLog


### PR DESCRIPTION
This import got lost in my rebasing. Reported over in (#186)
