### PR TITLE
Don't append empty strings

### DIFF
--- a/beaver/worker/tail.py
+++ b/beaver/worker/tail.py
@@ -145,7 +145,9 @@ class Tail(BaseLog):
 
         # Move the first entry in the resulting array into the input buffer.  It represents
         # the last segment of a token-delimited entity unless it's the only entry in the list.
-        self._input.append(entities.popleft())
+        first_entry = entities.popleft()
+        if len(first_entry) > 0:
+            self._input.append(first_entry)
 
         # If the resulting array from the split is empty, the token was not encountered
         # (not even at the end of the buffer).  Since we've encountered no token-delimited

--- a/beaver/worker/worker.py
+++ b/beaver/worker/worker.py
@@ -197,7 +197,9 @@ class Worker(object):
 
         # Move the first entry in the resulting array into the input buffer.  It represents
         # the last segment of a token-delimited entity unless it's the only entry in the list.
-        self._file_map[fid]['input'].append(entities.popleft())
+        first_entry = entities.popleft()
+        if len(first_entry) > 0:
+            self._file_map[fid]['input'].append(first_entry)
 
         # If the resulting array from the split is empty, the token was not encountered
         # (not even at the end of the buffer).  Since we've encountered no token-delimited


### PR DESCRIPTION
When a file is watched but not changed we keep appending empty strings into its input queue. 
Causing it grow unhindered. Thoughts? 
