### PR TITLE
Add SSL/TLS support to the RabbitMQ transport

### DIFF
--- a/beaver/config.py
+++ b/beaver/config.py
@@ -57,6 +57,10 @@ class BeaverConfig():
             'mqtt_keepalive': '60',
             'rabbitmq_host': os.environ.get('RABBITMQ_HOST', 'localhost'),
             'rabbitmq_port': os.environ.get('RABBITMQ_PORT', '5672'),
+            'rabbitmq_ssl': '0'
+            'rabbitmq_ssl_key': None,
+            'rabbitmq_ssl_cert': None,
+            'rabbitmq_ssl_cacert': None,
             'rabbitmq_vhost': os.environ.get('RABBITMQ_VHOST', '/'),
             'rabbitmq_username': os.environ.get('RABBITMQ_USERNAME', 'guest'),
             'rabbitmq_password': os.environ.get('RABBITMQ_PASSWORD', 'guest'),
@@ -260,7 +264,7 @@ class BeaverConfig():
                     config[key] = None
 
             require_bool = ['debug', 'daemonize', 'fqdn', 'rabbitmq_exchange_durable', 'rabbitmq_queue_durable',
-                            'rabbitmq_ha_queue', 'tcp_ssl_enabled', 'tcp_ssl_verify']
+                            'rabbitmq_ha_queue', 'rabbitmq_ssl', 'tcp_ssl_enabled', 'tcp_ssl_verify']
 
             for key in require_bool:
                 config[key] = bool(int(config[key]))

--- a/beaver/transports/rabbitmq_transport.py
+++ b/beaver/transports/rabbitmq_transport.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pika
+import ssl
 
 from beaver.transports.base_transport import BaseTransport
 from beaver.transports.exception import TransportException
@@ -13,7 +14,8 @@ class RabbitmqTransport(BaseTransport):
         self._rabbitmq_config = {}
         config_to_store = [
             'key', 'exchange', 'username', 'password', 'host', 'port', 'vhost',
-            'queue', 'queue_durable', 'ha_queue', 'exchange_type', 'exchange_durable'
+            'queue', 'queue_durable', 'ha_queue', 'exchange_type', 'exchange_durable',
+            'ssl', 'ssl_key', 'ssl_cert', 'ssl_cacert'
         ]
 
         for key in config_to_store:
@@ -30,10 +32,18 @@ class RabbitmqTransport(BaseTransport):
             self._rabbitmq_config['username'],
             self._rabbitmq_config['password']
         )
+        ssl_options = {
+            'keyfile': self._rabbitmq_config['ssl_key'],
+            'certfile': self._rabbitmq_config['ssl_cert'],
+            'ca_certs': self._rabbitmq_config['ssl_cacert'],
+            'ssl_version': ssl.PROTOCOL_TLSv1
+        }
         parameters = pika.connection.ConnectionParameters(
             credentials=credentials,
             host=self._rabbitmq_config['host'],
             port=self._rabbitmq_config['port'],
+            ssl=self._rabbitmq_config['ssl'],
+            ssl_options=ssl_options,
             virtual_host=self._rabbitmq_config['vhost']
         )
         self._connection = pika.adapters.BlockingConnection(parameters)

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -50,6 +50,10 @@ Beaver can optionally get data from a ``configfile`` using the ``-c`` flag. This
 * mqtt_topic: Default ``/logstash``. Topic to publish to
 * rabbitmq_host: Defaults ``localhost``. Host for RabbitMQ
 * rabbitmq_port: Defaults ``5672``. Port for RabbitMQ
+* rabbitmq_ssl: Defaults ``0``. Connect using SSL/TLS
+* rabbitmq_ssl_key: Optional. Defaults ``None``. Path to client private key for SSL/TLS
+* rabbitmq_ssl_cert: Optional. Defaults ``None``. Path to client certificate for SSL/TLS
+* rabbitmq_ssl_cacert: Optional. Defaults ``None``. Path to CA certificate for SSL/TLS
 * rabbitmq_vhost: Default ``/``
 * rabbitmq_username: Default ``guest``
 * rabbitmq_password: Default ``guest``


### PR DESCRIPTION
Adds configuration options for connecting to rabbitmq over ssl.
