### PR TITLE
Use GlobSafeConfigParser to parse config files

### DIFF
--- a/beaver/config.py
+++ b/beaver/config.py
@@ -7,7 +7,7 @@ import warnings
 
 from conf_d import Configuration
 from beaver.utils import eglob
-
+from beaver.glob_safe_config_parser import GlobSafeConfigParser
 
 class BeaverConfig():
 
@@ -142,6 +142,7 @@ class BeaverConfig():
         }
 
         self._configfile = args.config
+        self._config_parser = GlobSafeConfigParser
         self._globbed = []
         self._parse(args)
         for key in self._beaver_config:
@@ -405,7 +406,8 @@ class BeaverConfig():
             section_defaults=self._section_defaults,
             main_parser=_main_parser,
             section_parser=_section_parser,
-            path_from_main='confd_path'
+            path_from_main='confd_path',
+            config_parser=self._config_parser
         )
 
         config = conf.raw()

--- a/beaver/glob_safe_config_parser.py
+++ b/beaver/glob_safe_config_parser.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+import ConfigParser
+import re
+
+"""
+Allows use of square brackets in .ini section names, which are used in some globs.
+Based off of python 2.6 ConfigParser.RawConfigParser source code with a few modifications.
+http://hg.python.org/cpython/file/8c4d42c0dc8e/Lib/configparser.py
+"""
+class GlobSafeConfigParser(ConfigParser.RawConfigParser):
+
+    OPTCRE = re.compile(
+        r'(?P<option>[^:=\s][^:=]*)'
+        r'\s*(?P<vi>[:=])\s*'       
+        r'(?P<value>.*)$'           
+        )
+
+    def _read(self, fp, fpname):
+        cursect = None
+        optname = None
+        lineno = 0
+        e = None
+        while True:
+            line = fp.readline()
+            if not line:
+                break
+            lineno = lineno + 1
+            if line.strip() == '' or line[0] in '#;':
+                continue
+            if line.split(None, 1)[0].lower() == 'rem' and line[0] in "rR":
+                continue
+            if line[0].isspace() and cursect is not None and optname:
+                value = line.strip()
+                if value:
+                    cursect[optname] = "%s\n%s" % (cursect[optname], value)
+            else:
+                try:
+                  value = line[:line.index(';')].strip()
+                except ValueError:
+                  value = line.strip()
+
+                if  value[0]=='[' and value[-1]==']' and len(value)>2:
+                    sectname = value[1:-1]
+                    if sectname in self._sections:
+                        cursect = self._sections[sectname]
+                    elif sectname == "DEFAULT":
+                        cursect = self._defaults
+                    else:
+                        cursect = self._dict()
+                        cursect['__name__'] = sectname
+                        self._sections[sectname] = cursect
+                    optname = None
+                elif cursect is None:
+                    raise MissingSectionHeaderError(fpname, lineno, line)
+                else:
+                    mo = self.OPTCRE.match(line)
+                    if mo:
+                        optname, vi, optval = mo.group('option', 'vi', 'value')
+                        if vi in ('=', ':') and ';' in optval:
+                            pos = optval.find(';')
+                            if pos != -1 and optval[pos-1].isspace():
+                                optval = optval[:pos]
+                        optval = optval.strip()
+                        if optval == '""':
+                            optval = ''
+                        optname = self.optionxform(optname.rstrip())
+                        cursect[optname] = optval
+                    else:
+                        if not e:
+                            e = ParsingError(fpname)
+                        e.append(lineno, repr(line))
+        if e:
+            raise e

--- a/beaver/tests/test_glob_sections.py
+++ b/beaver/tests/test_glob_sections.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+import unittest 
+import os
+import glob
+from beaver.config import BeaverConfig
+
+class ConfigTests(unittest.TestCase):
+
+    def setUp(self):
+        self.config = lambda: None
+        self.config.config = 'tests/square_bracket_sections.ini'
+        self.config.mode = 'bind'
+        self.beaver_config = BeaverConfig(self.config)
+
+    def test_globs(self):
+        files = [os.path.realpath(x) for x in glob.glob('tests/logs/0x[0-9]*.log')]
+        for file in self.beaver_config.getfilepaths():
+            self.assertTrue(file in files)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 boto==2.8.0
-conf_d>=0.0.3
+conf_d>=0.0.4
 glob2==0.3
 mosquitto>=1.1
 msgpack-pure>=0.1.3

--- a/tests/square_bracket_sections.ini
+++ b/tests/square_bracket_sections.ini
@@ -1,0 +1,2 @@
+[./tests/logs/0x[0-9]*.log] ; paths are relative to your current path
+type: logs


### PR DESCRIPTION
In order to support all of the kinds of globs (esp. ones with square 
brackets), pass GlobSafeConfigParser into the Configuration object
so that it parses section headers correctly.
