### PR TITLE
Adding missing config file option 'rabbitmq_queue_durable'.

### DIFF
--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -54,6 +54,7 @@ Beaver can optionally get data from a ``configfile`` using the ``-c`` flag. This
 * rabbitmq_username: Default ``guest``
 * rabbitmq_password: Default ``guest``
 * rabbitmq_queue: Default ``logstash-queue``.
+* rabbitmq_queue_durable: Default ``0``.
 * rabbitmq_exchange_type: Default ``direct``.
 * rabbitmq_exchange_durable: Default ``0``.
 * rabbitmq_key: Default ``logstash-key``.


### PR DESCRIPTION
This config file option was missing in the docs; I didn't realize it existed until I randomly tried it and it solved my problem.
