### PR TITLE
When shipping logs, use millisecond-precision timestamps.

### DIFF
--- a/beaver/transports/base_transport.py
+++ b/beaver/transports/base_transport.py
@@ -120,7 +120,8 @@ class BaseTransport(object):
         """Retrieves the timestamp for a given set of data"""
         timestamp = kwargs.get('timestamp')
         if not timestamp:
-            timestamp = datetime.datetime.utcnow().isoformat() + 'Z'
+            now = datetime.datetime.utcnow()
+            timestamp = now.strftime("%Y-%m-%dT%H:%M:%S") + ".%03d" % (now.microsecond / 1000) + "Z"
 
         return timestamp
 

--- a/beaver/worker/tail.py
+++ b/beaver/worker/tail.py
@@ -269,13 +269,15 @@ class Tail(BaseLog):
             self._sincedb_update_position(lines=line_count, force_update=True)
 
     def _callback_wrapper(self, lines):
+        now = datetime.datetime.utcnow()
+        timestamp = now.strftime("%Y-%m-%dT%H:%M:%S") + ".%03d" % (now.microsecond / 1000) + "Z"
         self._callback(('callback', {
             'fields': self._fields,
             'filename': self._filename,
             'format': self._format,
             'ignore_empty': self._ignore_empty,
             'lines': lines,
-            'timestamp': datetime.datetime.utcnow().isoformat() + 'Z',
+            'timestamp': timestamp,
             'tags': self._tags,
             'type': self._type,
         }))

--- a/beaver/worker/worker.py
+++ b/beaver/worker/worker.py
@@ -338,13 +338,15 @@ class Worker(object):
         self.unwatch_list(unwatch_list)
 
     def _callback_wrapper(self, filename, lines):
+        now = datetime.datetime.utcnow()
+        timestamp = now.strftime("%Y-%m-%dT%H:%M:%S") + ".%03d" % (now.microsecond / 1000) + "Z"
         self._callback(('callback', {
             'fields': self._beaver_config.get_field('fields', filename),
             'filename': filename,
             'format': self._beaver_config.get_field('format', filename),
             'ignore_empty': self._beaver_config.get_field('ignore_empty', filename),
             'lines': lines,
-            'timestamp': datetime.datetime.utcnow().isoformat() + "Z",
+            'timestamp': timestamp,
             'tags': self._beaver_config.get_field('tags', filename),
             'type': self._beaver_config.get_field('type', filename),
         }))


### PR DESCRIPTION
Logstash 1.3.2 has a problem with microsecond-precision timestamps in the
@timestamp field, which is the default behavior of Python's .isoformat
method. Logstash uses the JodaTime library to parse timestamps, and Joda
doesn’t support nanosecond timestamp resolution. As a result, Logstash
1.3.2 throws an exception on every log item shipped from Beaver.

There's a discussion about this issue in the logstash-users mailing list,
including an example of the Logstash exception:
    https://groups.google.com/forum/#!topic/logstash-users/wIzdv15Iefs

This patch reduces @timestamp to millisecond precision, which should
correct the problem with Beaver 1.3.2.
