### PR TITLE
Allow for newer versions of boto to be used

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-boto==2.8.0
+boto>=2.8.0
 conf_d>=0.0.3
 glob2==0.3
 mosquitto>=1.1


### PR DESCRIPTION
2.8.0 is a fairly old version of boto and doesn't have near the features that newer versions have. This change will allow beaver to use newer versions of boto. The only thing that appears to use boto within beaver is the SQS transport. I verified that it still functions with the latest version of boto.
