### PR TITLE
Fix redis_transport.py redis exception handling. Fixes #238

### DIFF
--- a/beaver/transports/redis_transport.py
+++ b/beaver/transports/redis_transport.py
@@ -65,6 +65,6 @@ class RedisTransport(BaseTransport):
 
         try:
             self._pipeline.execute()
-        except redis.exceptions.ConnectionError, e:
+        except redis.exceptions.RedisError, e:
             traceback.print_exc()
             raise TransportException(str(e))


### PR DESCRIPTION
Currently catch only `redis.exceptions.ConnectionError` is handled by `redis_transport.py`, but redis can raise different exceptions, and when it does, it is not handled correctly by beaver.

A list of exceptions can be found at https://github.com/andymccurdy/redis-py/blob/81a4a31779af0a608dcd04bfc3d33995aaa87272/redis/exceptions.py

This patch solves the issue because it catches the base exception, the one all redis exceptions inherit from.
