### PR TITLE
zmq3 split HWM into SNDHWM/RCVHWM. Closes #246

### DIFF
--- a/beaver/transports/zmq_transport.py
+++ b/beaver/transports/zmq_transport.py
@@ -19,7 +19,11 @@ class ZmqTransport(BaseTransport):
 
         zeromq_hwm = beaver_config.get('zeromq_hwm')
         if zeromq_hwm:
-            self._pub.hwm = zeromq_hwm
+            if hasattr(self._pub, 'HWM'): # ZeroMQ < 3
+                self._pub.setsockopt(zmq.HWM, zeromq_hwm)
+            else:
+                self._pub.setsockopt(zmq.SNDHWM, zeromq_hwm)
+                self._pub.setsockopt(zmq.RCVHWM, zeromq_hwm)
 
         if beaver_config.get('mode') == 'bind':
             for addr in zeromq_addresses:


### PR DESCRIPTION
Fixes #246. In zeromq3, the hwm (high watermark) socket option has been split into sndhwm/rcvhwm. Tested on CentOS 6 with zeromq3-3.2.4-1.el6 and python-zmq-2.2.0.1-1.el6 packages.
