### PR TITLE
Added multiline_regex_begin option for multiline parsing

### DIFF
--- a/beaver/config.py
+++ b/beaver/config.py
@@ -40,6 +40,7 @@ class BeaverConfig():
             # multiline events support. Default is disabled
             'multiline_regex_after': '',
             'multiline_regex_before': '',
+            'multiline_regex_begin': '',
 
             'message_format': '',
             'sincedb_write_interval': '15',
@@ -421,6 +422,8 @@ class BeaverConfig():
                 config['multiline_regex_after'] = re.compile(config['multiline_regex_after'])
             if config['multiline_regex_before']:
                 config['multiline_regex_before'] = re.compile(config['multiline_regex_before'])
+            if config['multiline_regex_begin']:
+                config['multiline_regex_begin'] = re.compile(config['multiline_regex_begin'])
 
             require_int = ['sincedb_write_interval', 'stat_interval', 'tail_lines']
             for k in require_int:

--- a/beaver/utils.py
+++ b/beaver/utils.py
@@ -152,7 +152,7 @@ def _replace_all(path, replacements):
     return path
 
 
-def multiline_merge(lines, current_event, re_after, re_before):
+def multiline_merge(lines, current_event, re_after, re_before, re_begin):
     """ Merge multi-line events based.
 
         Some event (like Python trackback or Java stracktrace) spawn
@@ -162,6 +162,8 @@ def multiline_merge(lines, current_event, re_after, re_before):
         If a line match re_after, it will be merged with next line.
 
         If a line match re_before, it will be merged with previous line.
+
+        If a line don't match re_begin, it will be merged with previous line.
 
         This function return a list of complet event. Note that because
         we don't know if an event is complet before another new event
@@ -175,6 +177,8 @@ def multiline_merge(lines, current_event, re_after, re_before):
         if re_before and re_before.match(line):
             current_event.append(line)
         elif re_after and current_event and re_after.match(current_event[-1]):
+            current_event.append(line)
+        elif re_begin and not re_begin.match(line):
             current_event.append(line)
         else:
             if current_event:

--- a/beaver/worker/tail.py
+++ b/beaver/worker/tail.py
@@ -66,6 +66,7 @@ class Tail(BaseLog):
         self._last_activity = time.time()
         self._multiline_regex_after = beaver_config.get_field('multiline_regex_after', filename)
         self._multiline_regex_before = beaver_config.get_field('multiline_regex_before', filename)
+        self._multiline_regex_begin = beaver_config.get_field('multiline_regex_begin', filename)
 
         self._update_file()
         if self.active:
@@ -250,13 +251,14 @@ class Tail(BaseLog):
 
             self._last_activity = time.time()
 
-            if self._multiline_regex_after or self._multiline_regex_before:
+            if self._multiline_regex_after or self._multiline_regex_before or self._multiline_regex_begin:
                 # Multiline is enabled for this file.
                 events = multiline_merge(
                         lines,
                         self._current_event,
                         self._multiline_regex_after,
-                        self._multiline_regex_before)
+                        self._multiline_regex_before,
+                        self._multiline_regex_begin)
             else:
                 events = lines
 
@@ -333,13 +335,14 @@ class Tail(BaseLog):
             self._log_debug('tailing {0} lines'.format(self._tail_lines))
             lines = self.tail(self._filename, encoding=self._encoding, window=self._tail_lines, position=current_position)
             if lines:
-                if self._multiline_regex_after or self._multiline_regex_before:
+                if self._multiline_regex_after or self._multiline_regex_before or self._multiline_regex_begin:
                     # Multiline is enabled for this file.
                     events = multiline_merge(
                             lines,
                             self._current_event,
                             self._multiline_regex_after,
-                            self._multiline_regex_before)
+                            self._multiline_regex_before,
+                            self._multiline_regex_begin)
                 else:
                     events = lines
                 self._callback_wrapper(events)

--- a/beaver/worker/worker.py
+++ b/beaver/worker/worker.py
@@ -153,13 +153,14 @@ class Worker(object):
 
             self._file_map[fid]['last_activity'] = time.time()
 
-            if self._file_map[fid]['multiline_regex_after'] or self._file_map[fid]['multiline_regex_before']:
+            if self._file_map[fid]['multiline_regex_after'] or self._file_map[fid]['multiline_regex_before'] or self._file_map[fid]['multiline_regex_begin']:
                 # Multiline is enabled for this file.
                 events = multiline_merge(
                         lines,
                         self._file_map[fid]['current_event'],
                         self._file_map[fid]['multiline_regex_after'],
-                        self._file_map[fid]['multiline_regex_before'])
+                        self._file_map[fid]['multiline_regex_before'],
+                        self._file_map[fid]['multiline_regex_begin'])
             else:
                 events = lines
 
@@ -324,13 +325,14 @@ class Worker(object):
 
                 lines = self.tail(data['file'].name, encoding=encoding, window=tail_lines, position=current_position)
                 if lines:
-                    if self._file_map[fid]['multiline_regex_after'] or self._file_map[fid]['multiline_regex_before']:
+                    if self._file_map[fid]['multiline_regex_after'] or self._file_map[fid]['multiline_regex_before'] or self._file_map[fid]['multiline_regex_begin']:
                         # Multiline is enabled for this file.
                         events = multiline_merge(
                                 lines,
                                 self._file_map[fid]['current_event'],
                                 self._file_map[fid]['multiline_regex_after'],
-                                self._file_map[fid]['multiline_regex_before'])
+                                self._file_map[fid]['multiline_regex_before'],
+                                self._file_map[fid]['multiline_regex_begin'])
                     else:
                         events = lines
                     self._callback_wrapper(filename=data['file'].name, lines=events)
@@ -591,6 +593,7 @@ class Worker(object):
                     'line': 0,
                     'multiline_regex_after': self._beaver_config.get_field('multiline_regex_after', fname),
                     'multiline_regex_before': self._beaver_config.get_field('multiline_regex_before', fname),
+                    'multiline_regex_begin': self._beaver_config.get_field('multiline_regex_begin', fname),
                     'size_limit': self._beaver_config.get_field('size_limit', fname),
                     'update_time': None,
                     'active': True,

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -104,7 +104,7 @@ The following configuration keys are for multi-line events support and are per f
 
 * multiline_regex_after: Default ``None``. If a line match this regular expression, it will be merged with next line(s).
 * multiline_regex_before: Default ``None``. If a line match this regular expression, it will be merged with previous line(s).
-* multiline_regex_begin: Default ``None``.  If a line don't match this regular expression, it will be merged with previous line(s).
+* multiline_regex_begin: Default ``None``.  If a line doesn't match this regular expression, it will be merged with previous line(s).
 
 The following can also be passed via argparse. Argparse will override all options in the configfile, when specified.
 

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -104,6 +104,7 @@ The following configuration keys are for multi-line events support and are per f
 
 * multiline_regex_after: Default ``None``. If a line match this regular expression, it will be merged with next line(s).
 * multiline_regex_before: Default ``None``. If a line match this regular expression, it will be merged with previous line(s).
+* multiline_regex_begin: Default ``None``.  If a line don't match this regular expression, it will be merged with previous line(s).
 
 The following can also be passed via argparse. Argparse will override all options in the configfile, when specified.
 


### PR DESCRIPTION
I have log lines from log4j that sometimes have random line that is not space so I needed more strict method for multiline parsing like multiline_regex_begin.