### PR TITLE
remove `python-daemon` from requirements on win32

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,11 @@ requirements = open('requirements/base.txt').readlines()
 if sys.version_info[:2] <= (2, 6):
     requirements.extend(open('requirements/base26.txt').readlines())
 
+# python-daemon is not supported on windows
+if sys.platform == 'win32':
+    pd = filter(lambda r: r.startswith('python-daemon'), requirements)[0]
+    requirements.remove(pd)
+
 setup(
     name='Beaver',
     version=__version__,


### PR DESCRIPTION
If we're installing on windows, don't require `python-daemon`. This
fixes a problem where trying to `pip install beaver` errors out when
trying to install `python-daemon`.

refs #141 
