### PR TITLE
Improve rabbitmq reconnect behaviour

### DIFF
--- a/beaver/run_queue.py
+++ b/beaver/run_queue.py
@@ -30,10 +30,6 @@ def run_queue(queue, beaver_config, logger=None):
                 logger.info('Transport connection issues, stopping queue')
                 break
 
-            if int(time.time()) - last_update_time > queue_timeout:
-                logger.info('Queue timeout of "{0}" seconds exceeded, stopping queue'.format(queue_timeout))
-                break
-
             command = None
             try:
                 if queue.full():
@@ -53,6 +49,10 @@ def run_queue(queue, beaver_config, logger=None):
                     break
                 else:
                     logger.debug('No data')
+
+            if int(time.time()) - last_update_time > queue_timeout:
+                logger.info('Queue timeout of "{0}" seconds exceeded, stopping queue'.format(queue_timeout))
+                break
 
             if command == 'callback':
                 if data.get('ignore_empty', False):

--- a/beaver/run_queue.py
+++ b/beaver/run_queue.py
@@ -76,13 +76,14 @@ def run_queue(queue, beaver_config, logger=None):
                         count += 1
                         logger.debug("Number of transports: " + str(count))
                         break
-                    except TransportException:
+                    except TransportException, e:
                         failure_count = failure_count + 1
                         if failure_count > beaver_config.get('max_failure'):
                             failure_count = beaver_config.get('max_failure')
 
                         sleep_time = beaver_config.get('respawn_delay') ** failure_count
-                        logger.info('Caught transport exception, reconnecting in %d seconds' % sleep_time)
+                        logger.info('Caught transport exception: %s', e)
+                        logger.info('Reconnecting in %d seconds' % sleep_time)
 
                         try:
                             transport.invalidate()

--- a/beaver/tests/test_transport_config.py
+++ b/beaver/tests/test_transport_config.py
@@ -44,6 +44,7 @@ with mock.patch('pika.adapters.SelectConnection') as mock_pika:
             beaver_config = self._get_config(transport='rabbitmq')
             transport = create_transport(beaver_config, logger=self.logger)
             self.assertIsInstance(transport, beaver.transports.rabbitmq_transport.RabbitmqTransport)
+            transport.interrupt()
 
         @mock.patch('redis.StrictRedis', fakeredis.FakeStrictRedis)
         def test_builtin_redis(self):

--- a/beaver/transports/rabbitmq_transport.py
+++ b/beaver/transports/rabbitmq_transport.py
@@ -28,109 +28,104 @@ class RabbitmqTransport(BaseTransport):
         self._channel = None
         self._count = 0
         self._lines = Queue()
+        self._connection_ok = False
+        self._thread = None
+        self._is_valid = True
         self._connect()
 
     def _on_connection_open(self,connection):
-        self._logger.debug("connection created")
+        self._logger.debug("RabbitMQ: Connection Created")
         self._channel = connection.channel(self._on_channel_open)
 
     def _on_channel_open(self,unused):
-        self._logger.debug("Channel Created")
+        self._logger.debug("RabbitMQ: Channel Created")
         self._channel.exchange_declare(self._on_exchange_declareok,
                                        exchange=self._rabbitmq_config['exchange'],
                                        exchange_type=self._rabbitmq_config['exchange_type'],
                                        durable=self._rabbitmq_config['exchange_durable'])
 
     def _on_exchange_declareok(self,unused):
-        self._logger.debug("Exchange Declared")
+        self._logger.debug("RabbitMQ: Exchange Declared")
         self._channel.queue_declare(self._on_queue_declareok,
                                     queue=self._rabbitmq_config['queue'],
                                     durable=self._rabbitmq_config['queue_durable'],
                                     arguments={'x-ha-policy': 'all'} if self._rabbitmq_config['ha_queue'] else {})
 
     def _on_queue_declareok(self,unused):
-        self._logger.debug("Queue Declared")
+        self._logger.debug("RabbitMQ: Queue Declared")
         self._channel.queue_bind(self._on_bindok,
                                  exchange=self._rabbitmq_config['exchange'],
                                  queue=self._rabbitmq_config['queue'],
                                  routing_key=self._rabbitmq_config['key'])
 
     def _on_bindok(self,unused):
-        self._logger.debug("Exchange to Queue Bind OK")
-        self._is_valid = True;
-        self._logger.debug("Scheduling next message for %0.1f seconds",1)
-        self._connection.add_timeout(1,self._publish_message)
-
+        self._logger.info("RabbitMQ: Connection OK.")
+        self._connection_ok = True
+        self._logger.debug("RabbitMQ: Scheduling regular message transport.")
+        self._connection.add_timeout(1, self._publish_message)
 
     def _publish_message(self):
-        while True:
-            self._count += 0
-            if self._lines.not_empty:
-                line = self._lines.get()
-                if self._count == 10000:
-                    self._logger.debug("RabbitMQ transport queue size: %s" % (self._lines.qsize(), ))
-                    self._count = 0
-                else:
-                    self._count += 1
-                if self._channel != None:
-                    self._channel.basic_publish(
-                            exchange=self._rabbitmq_config['exchange'],
-                            routing_key=self._rabbitmq_config['key'],
-                            body=line,
-                            properties=pika.BasicProperties(
-                                content_type='text/json',
-                                delivery_mode=self._rabbitmq_config['delivery_mode']
-                            ))
+        self._logger.debug("RabbitMQ: Looking for messages to transport...")
+        while self._connection_ok and not self._lines.empty():
+            line = self._lines.get()
+            if self._count == 10000:
+                self._logger.debug("RabbitMQ: Transport queue size: %s", self._lines.qsize())
+                self._count = 0
             else:
-                self._logger.debug("RabbitMQ transport queue is empty, sleeping for 1 second.")
-                time.sleep(1)
+                self._count += 1
+            self._channel.basic_publish(
+                exchange=self._rabbitmq_config['exchange'],
+                routing_key=self._rabbitmq_config['key'],
+                body=line,
+                properties=pika.BasicProperties(
+                    content_type='text/json',
+                    delivery_mode=self._rabbitmq_config['delivery_mode']
+                ))
+        if self._connection_ok:
+            self._logger.debug("RabbitMQ: No messages to transport. Sleeping.")
+            self._connection.add_timeout(1, self._publish_message)
+        else:
+            self._logger.info('RabbitMQ: Message publisher stopped.')
 
-
-
-    def _on_connection_open_error(self,non_used_connection=None,error=None):
-        self._logger.debug("connection open error")
-        if not error==None:
-            self._logger.error(error)
+    def _on_connection_open_error(self, non_used_connection=None, error=None):
+        self._connection_ok = False
+        self._logger.error('RabbitMQ: Could not open connection: %s', error)
 
     def _on_connection_closed(self, connection, reply_code, reply_text):
-        self._channel = None
-        if hasattr(self._connection, '_closing'):
-            closing = self._connection._closing
-        elif hasattr(self._connection, 'is_closing'):
-            closing = self._connection.is_closing
-        else:
-            raise NotImplementedError('Unsure how to check whether the connection is closing.')
-        if closing:
-            try:
-                self._connection.ioloop.stop()
-            except:
-                pass
-        else:
-            self._logger.warning('RabbitMQ Connection closed, reopening in 1 seconds: (%s) %s',
-                           reply_code, reply_text)
-            time.sleep(1)
-            self.reconnect()
+        self._connection_ok = False
+        self._logger.warning('RabbitMQ: Connection closed: %s %s', reply_code, reply_text)
 
     def reconnect(self):
-        try:
-            self._connection.ioloop.stop()
-        except:
-            pass
-        self._connection_start()
+        self._logger.debug("RabbitMQ: Reconnecting...")
+        self.interrupt()
+
+	self._thread = Thread(target=self._connection_start)
+	self._thread.start()
+        while self._thread.is_alive() and not self._connection_ok:
+            time.sleep(1)
+        if self._connection_ok:
+            self._is_valid = True
+            self._logger.info('RabbitMQ: Reconnect successful.')
+        else:
+            self._logger.warning('RabbitMQ: Reconnect failed!')
+            self.interrupt()
 
     def _connection_start(self):
-        self._logger.debug("Creating Connection")
+        self._logger.debug("RabbitMQ: Connecting...")
         try:
-            self._connection = pika.adapters.SelectConnection(parameters=self._parameters,on_open_callback=self._on_connection_open,on_open_error_callback=self._on_connection_open_error,on_close_callback=self._on_connection_closed,stop_ioloop_on_close=False)
-        except Exception,e:
-            self._logger.error("Failed Creating RabbitMQ connection")
-            self._logger.error(e)
-        self._logger.debug("Starting ioloop")
-        self._connection.ioloop.start()
+            self._connection_ok = False
+            self._connection = pika.adapters.SelectConnection(
+                parameters=self._parameters,
+                on_open_callback=self._on_connection_open,
+                on_open_error_callback=self._on_connection_open_error,
+                on_close_callback=self._on_connection_closed
+            )
+            if not self._connection.is_closed:
+                self._connection.ioloop.start()
+        except Exception, e:
+            self._logger.error('RabbitMQ: Failed to connect: %s', e)
 
     def _connect(self):
-
-        # Setup RabbitMQ connection
         credentials = pika.PlainCredentials(
             self._rabbitmq_config['username'],
             self._rabbitmq_config['password']
@@ -150,9 +145,12 @@ class RabbitmqTransport(BaseTransport):
             virtual_host=self._rabbitmq_config['vhost'],
             socket_timeout=self._rabbitmq_config['timeout']
         )
-        Thread(target=self._connection_start).start()
+        self._thread = Thread(target=self._connection_start)
+        self._thread.start()
 
     def callback(self, filename, lines, **kwargs):
+        if not self._connection_ok:
+            raise TransportException('RabbitMQ: Not connected or connection not OK')
         timestamp = self.get_timestamp(**kwargs)
         if kwargs.get('timestamp', False):
             del kwargs['timestamp']
@@ -164,18 +162,21 @@ class RabbitmqTransport(BaseTransport):
                     body = self.format(filename, line, timestamp, **kwargs)
                     self._lines.put(body)
             except UserWarning:
-                self._is_valid = False
                 raise TransportException('Connection appears to have been lost')
             except Exception as e:
-                self._is_valid = False
                 try:
                     raise TransportException(e.strerror)
                 except AttributeError:
-                    raise TransportException('Unspecified exception encountered')  # TRAP ALL THE THINGS!
+                    raise TransportException('Unspecified exception encountered')
 
     def interrupt(self):
+        self._connection_ok = False
         if self._connection:
             self._connection.close()
+            self._connection = None
+        if self._thread:
+            self._thread.join()
+            self._thread = None
 
     def unhandled(self):
         return True


### PR DESCRIPTION
Fixes #385 and #386

New behaviour:
* If a rabbitmq server closes the connection, try to reconnect as with other transports
* During this time, messages will be queued and delivered as soon as a connection comes back