### PR TITLE
Fix GitHub links

### DIFF
--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -38,19 +38,19 @@ Get the Code
 ------------
 
 Beaver is actively developed on GitHub, where the code is
-`always available <https://github.com/python-beaver/beaver>`_.
+`always available <https://github.com/python-beaver/python-beaver>`_.
 
 You can either clone the public repository::
 
-    git clone git://github.com/python-beaver/beaver.git
+    git clone git://github.com/python-beaver/python-beaver.git
 
-Download the `tarball <https://github.com/python-beaver/beaver/tarball/master>`_::
+Download the `tarball <https://github.com/python-beaver/python-beaver/tarball/master>`_::
 
-    $ curl -OL https://github.com/python-beaver/beaver/tarball/master
+    $ curl -OL https://github.com/python-beaver/python-beaver/tarball/master
 
-Or, download the `zipball <https://github.com/python-beaver/beaver/zipball/master>`_::
+Or, download the `zipball <https://github.com/python-beaver/python-beaver/zipball/master>`_::
 
-    $ curl -OL https://github.com/python-beaver/beaver/zipball/master
+    $ curl -OL https://github.com/python-beaver/python-beaver/zipball/master
 
 
 Once you have a copy of the source, you can embed it in your Python package,


### PR DESCRIPTION
The project was renamed to 'python-beaver', but the links in the docs do not reflect that change.