### PR TITLE
Avoid unreference variable 'st' error if file was removed. Raise exception if unrecognized environment error from os.stat

### DIFF
--- a/beaver/worker/tail.py
+++ b/beaver/worker/tail.py
@@ -207,6 +207,8 @@ class Tail(BaseLog):
             if err.errno == errno.ENOENT:
                 self._log_info('file removed')
                 self.close()
+                return
+            raise
 
         fid = self.get_file_id(st)
         if fid != self._fid:


### PR DESCRIPTION
Unit tests passing.
Did a manual test, and no crash, tailed file gets removed, and is added back if it appears again now.