### PR TITLE
Remove truncating of logline after 32766 chars

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ HTML docs will be available in `beaver/docs/_build/html`.
 Contributing
 ============
 
-When contributing to Beaver, please review the full guidelines here: https://github.com/python-beaver/python-beaver/blob/master/CONTRIBUTING.rst.
+When contributing to Beaver, please review the full guidelines here: https://github.com/python-beaver/python-beaver/blob/master/CONTRIBUTING.md.
 If you would like, you can open an issue to let others know about your work in progress. Documentation must be included and tests must pass on Python 2.6 and 2.7 for pull requests to be accepted.
 
 Credits

--- a/beaver/transports/base_transport.py
+++ b/beaver/transports/base_transport.py
@@ -116,7 +116,7 @@ class BaseTransport(object):
 
     def format(self, filename, line, timestamp, **kwargs):
         """Returns a formatted log line"""
-        line = unicode(line.encode("utf-8")[:32766], "utf-8", errors="ignore")
+        line = unicode(line.encode("utf-8"), "utf-8", errors="ignore")
         formatter = self._beaver_config.get_field('format', filename)
         if formatter not in self._formatters:
             formatter = self._default_formatter

--- a/beaver/utils.py
+++ b/beaver/utils.py
@@ -197,6 +197,8 @@ def multiline_merge(lines, current_event, re_after, re_before):
     """
     events = []
     for line in lines:
+        if line == '':
+            break
         if re_before and re_before.match(line):
             current_event.append(line)
         elif re_after and current_event and re_after.match(current_event[-1]):

--- a/beaver/utils.py
+++ b/beaver/utils.py
@@ -197,8 +197,6 @@ def multiline_merge(lines, current_event, re_after, re_before):
     """
     events = []
     for line in lines:
-        if line == '':
-            break
         if re_before and re_before.match(line):
             current_event.append(line)
         elif re_after and current_event and re_after.match(current_event[-1]):

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-pip install -r requirements/zeromq.txt -r requirements/tests.txt --use-mirrors
+pip install -r requirements/zeromq.txt -r requirements/tests.txt
 
 mkdir ~/.aws/
 cat > ~/.aws/credentials << EOL

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -5,4 +5,4 @@ nose
 six
 unittest2
 coveralls
-moto
+moto==0.4.31


### PR DESCRIPTION
It is not necessary to limit unicode()'s input to 32766 chars, while
doing puts an arbitrary limit on the length of lines beaver can
handle.