### PR TITLE
Revert "multiline_regex_before won't work when logfile ends with empty line"

### DIFF
--- a/beaver/utils.py
+++ b/beaver/utils.py
@@ -197,8 +197,6 @@ def multiline_merge(lines, current_event, re_after, re_before):
     """
     events = []
     for line in lines:
-        if line == '':
-            break
         if re_before and re_before.match(line):
             current_event.append(line)
         elif re_after and current_event and re_after.match(current_event[-1]):


### PR DESCRIPTION
Reverts python-beaver/python-beaver#404 as it breaks py2.6 tests