### PR TITLE
Add arbitrary rabbitmq args

### DIFF
--- a/beaver/config.py
+++ b/beaver/config.py
@@ -82,7 +82,7 @@ class BeaverConfig():
             'rabbitmq_exchange_durable': os.environ.get('RABBITMQ_EXCHANGE_DURABLE', '0'),
             'rabbitmq_queue_durable': os.environ.get('RABBITMQ_QUEUE_DURABLE', '0'),
             'rabbitmq_ha_queue': os.environ.get('RABBITMQ_HA_QUEUE', '0'),
-            'rabbitmq_arguments': os.environ.get('RABBIT_ARGUMENTS', {}),
+            'rabbitmq_arguments': os.environ.get('RABBITMQ_ARGUMENTS', {}),
             'rabbitmq_key': os.environ.get('RABBITMQ_KEY', 'logstash-key'),
             'rabbitmq_exchange': os.environ.get('RABBITMQ_EXCHANGE', 'logstash-exchange'),
             'rabbitmq_timeout': '1',

--- a/beaver/config.py
+++ b/beaver/config.py
@@ -82,6 +82,7 @@ class BeaverConfig():
             'rabbitmq_exchange_durable': os.environ.get('RABBITMQ_EXCHANGE_DURABLE', '0'),
             'rabbitmq_queue_durable': os.environ.get('RABBITMQ_QUEUE_DURABLE', '0'),
             'rabbitmq_ha_queue': os.environ.get('RABBITMQ_HA_QUEUE', '0'),
+            'rabbitmq_arguments': os.environ.get('RABBIT_ARGUMENTS', {}),
             'rabbitmq_key': os.environ.get('RABBITMQ_KEY', 'logstash-key'),
             'rabbitmq_exchange': os.environ.get('RABBITMQ_EXCHANGE', 'logstash-exchange'),
             'rabbitmq_timeout': '1',
@@ -248,6 +249,7 @@ class BeaverConfig():
 
     def _check_for_deprecated_usage(self):
         env_vars = [
+            'RABBITMQ_ARGUMENTS'
             'RABBITMQ_HOST',
             'RABBITMQ_PORT',
             'RABBITMQ_VHOST',

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -58,6 +58,7 @@ Beaver can optionally get data from a ``configfile`` using the ``-c`` flag. This
 * mqtt_keepalive: Default ``60``. mqtt keepalive ping
 * mqtt_topic: Default ``/logstash``. Topic to publish to
 * number_of_consumer_processes: Default ``1``. Number of parallel consumer processes that read and process messages from the beaver queue.
+* rabbitmq_arguments: Defaults ``{}``. RabbitMQ arguments comma separated, colon separated key value pairs. i.e ``rabbitmq_arguments: x-max-length:750000,x-max-length-bytes:1073741824``
 * rabbitmq_host: Defaults ``localhost``. Host for RabbitMQ
 * rabbitmq_port: Defaults ``5672``. Port for RabbitMQ
 * rabbitmq_ssl: Defaults ``0``. Connect using SSL/TLS


### PR DESCRIPTION
This fixes #430 

Updates transport to allow arbitrary arguments from config, while still maintaining backwards compatibility with existing arguments. 

- arguments now default to an empty dictionary
- if 'ha_queues' is true, 'x-ha-policy' key is added to arguments, and set to 'all' 
- if arguments is set in config, arguments are parsed and added to arguments dict
