### PR TITLE
Require pika version below 1.0.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@ glob2==0.3
 kafka-python==0.9.5
 paho-mqtt==1.1
 msgpack-pure>=0.1.3
-pika>=0.9.14
+pika>=0.9.14,<1.0.0
 python-daemon>=1.5.2,<=1.6.1
 redis>=2.7.5
 requests


### PR DESCRIPTION
In this PR I lock down the required version of **pika** down the anything below `1.0.0` as they introduced a breaking change which lead to:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python2.7/dist-packages/beaver/run_queue.py", line 25, in run_queue
    transport = create_transport(beaver_config, logger=logger)
  File "/usr/local/lib/python2.7/dist-packages/beaver/transports/__init__.py", line 20, in create_transport
    transport = transport_class(beaver_config=beaver_config, logger=logger)
  File "/usr/local/lib/python2.7/dist-packages/beaver/transports/rabbitmq_transport.py", line 40, in __init__
    self._connect()
  File "/usr/local/lib/python2.7/dist-packages/beaver/transports/rabbitmq_transport.py", line 166, in _connect
    socket_timeout=self._rabbitmq_config['timeout']
  File "/usr/local/lib/python2.7/dist-packages/pika/connection.py", line 643, in __init__
    self.ssl_options = ssl_options
  File "/usr/local/lib/python2.7/dist-packages/pika/connection.py", line 491, in ssl_options
    'ssl_options must be None or SSLOptions but got %r' % (value,))
TypeError: ssl_options must be None or SSLOptions but got {'ca_certs': None, 'certfile': None, 'keyfile': None, 'ssl_version': 3}
```

When no ssl options are set at all.