### PR TITLE
Update http_transport.py

### DIFF
--- a/beaver/transports/http_transport.py
+++ b/beaver/transports/http_transport.py
@@ -2,6 +2,7 @@
 import traceback
 import time
 import requests
+import json
 
 from beaver.transports.base_transport import BaseTransport
 from beaver.transports.exception import TransportException
@@ -60,7 +61,18 @@ class HttpTransport(BaseTransport):
                 edata = jsonline.replace('\t', '\\t')
                 self._logger.debug('writing to : {0}'.format(self._url))
                 self._logger.debug('writing data: {0}'.format(edata))
-                r = requests.post(url=self._url, data=edata)
+                
+                try:
+                    isjson = json.loads(edata)
+                except ValueError:
+                    headers = {'content-type': 'application/x-www-form-urlencoded'}
+                else:
+                    headers = {'content-type': 'application/json'}
+                
+                r = requests.post(url=self._url, headers=headers, data=edata)
+                
+                self._logger.info('POST Status {0} - {1}'.format(r.status_code,headers))
+                
                 if r.status_code >= 200 and r.status_code < 300:
                     res = r.content
                 else:


### PR DESCRIPTION
The object edata is a string and when this is sent using 'r = requests.post(url=self._url, data=edata)' no content-type is sent by requests to the receiving web service. If a dict object was set instead requests would detect this and automatically apply a content-type.

This change checks if edata can be decoded as json and if it can adds appropriate header with content-type. If not it still adds a content-type to make the request more robust for the receiving server.

Prior to this change requests was seeing the status_code as a 500, even though it wasn't, because the reply from the web service had no content-type in the header since it didn't know what content-type it had received.