### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ included in the project:
    [interactive rebase](https://help.github.com/articles/about-git-rebase/)
    feature to tidy up your commits before making them public.
    - Test cases should accompany any change in functionality to the code-base
-   - Any change to end-user functionality should include corrosponding documentation
+   - Any change to end-user functionality should include corresponding documentation
 
 5. Locally merge (or rebase) the upstream development branch into your topic branch:
 

--- a/beaver/utils.py
+++ b/beaver/utils.py
@@ -180,7 +180,7 @@ def _replace_all(path, replacements):
 def multiline_merge(lines, current_event, re_after, re_before):
     """ Merge multi-line events based.
 
-        Some event (like Python trackback or Java stracktrace) spawn
+        Some event (like Python traceback or Java stacktrace) spawn
         on multiple line. This method will merge them using two
         regular expression: regex_after and regex_before.
 
@@ -188,8 +188,8 @@ def multiline_merge(lines, current_event, re_after, re_before):
 
         If a line match re_before, it will be merged with previous line.
 
-        This function return a list of complet event. Note that because
-        we don't know if an event is complet before another new event
+        This function return a list of complete event. Note that because
+        we don't know if an event is complete before another new event
         start, the last event will not be returned but stored in
         current_event. You should pass the same current_event to
         successive call to multiline_merge. current_event is a list


### PR DESCRIPTION
There are small typos in:
- CONTRIBUTING.md
- beaver/utils.py

Fixes:
- Should read `corresponding` rather than `corrosponding`.
- Should read `traceback` rather than `trackback`.
- Should read `stacktrace` rather than `stracktrace`.
- Should read `complete` rather than `complet`.

Closes #471